### PR TITLE
requiring >=0.30 for anchor-lang causes problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.dependencies]
 anchor-gen = "0"
-anchor-lang = ">=0.30"
+anchor-lang = ">=0.28"
 
 [dependencies]
 anchor-gen = { workspace = true }


### PR DESCRIPTION
spl-account-compression is pinned to anchor-lang 0.29.0. helium-lib uses spl-account-compression, so causes two versions of anchor-lang to exist.

Have been told that this project and all projects should be using 0.28.0 of anchor/solana related deps.

However, it is not feasible for everywhere downstream to go back to 0.28 because of solana-sdk version requirements.