### PR TITLE
pin anchor-lang to avoid downstream version float

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 
 [workspace.dependencies]
 anchor-gen = "0"
-anchor-lang = ">=0.28"
+anchor-lang = "=0.29"
 
 [dependencies]
 anchor-gen = { workspace = true }


### PR DESCRIPTION
We actually need to pin anchor-lang to avoid it floating to 0.30 which is quite incompatible 